### PR TITLE
Fix: Ensure UI updates after posting new track time

### DIFF
--- a/src/runtracker/components/trackpage.tsx
+++ b/src/runtracker/components/trackpage.tsx
@@ -38,6 +38,8 @@ export function TrackPage(props: TrackPageProps) {
             const currentPath: Track = queryclient.getQueryData(["track", trackId]) as Track;
             currentPath.times?.push(Time.of(savedTime));
             queryclient.setQueryData(["track", trackId], {...currentPath});
+            queryclient.invalidateQueries(["paths"]);
+            queryclient.invalidateQueries(["stats"]);
             //toastContext.showSuccessMessage(translate("newTime.saveSuccess"));
             notifications.show({
                 withCloseButton: true,


### PR DESCRIPTION
Previously, when a new track time was posted, only the local cache for the specific track page was updated. This meant that the main track list (showing summaries like best times) and the main statistics graph were not reflecting the new data immediately.

This change addresses the issue by invalidating the relevant React Query caches (`['paths']` and `['stats']`) upon the successful creation of a new track time. This triggers a refetch of the data for the main track list and the statistics graph, ensuring the UI updates accordingly.

The following components are now correctly updated:
- Main track list
- Main statistics graph
- Track times list on the individual track page (was already working but confirmed)